### PR TITLE
Return a timeout exit code if the execution times out

### DIFF
--- a/src/CLI/Console.php
+++ b/src/CLI/Console.php
@@ -158,7 +158,7 @@ class Console
 
             if ($timeout > 0 && \time() - $start > $timeout) {
                 \proc_terminate($process, 9);
-                return 1;
+                return 124;
             }
 
             $status = \proc_get_status($process);


### PR DESCRIPTION
This PR edits the return code for the execute function to return a 124 Unix timeout exit code if the execution times out