### PR TITLE
Get exitcode from proc_close if proc_get_status returns -1

### DIFF
--- a/src/CLI/Console.php
+++ b/src/CLI/Console.php
@@ -166,7 +166,12 @@ class Console
             if (!$status['running']) {
                 \fclose($pipes[1]);
                 \fclose($pipes[2]);
-                \proc_close($process);
+                
+                if ($status['exitcode'] === -1) {
+                    $status['exitcode'] = \proc_close($process);
+                } else {
+                    \proc_close($process);
+                }
 
                 return (int)$status['exitcode'];
             }


### PR DESCRIPTION
When PHP's `proc_get_status` returns that a process is no longer running sometimes (not sure why, could be swoole, could be IO operations) the process is still running. which means the exitCode is not available and is reported as -1.

This fix will fetch the exitcode from proc_close if the exitcode is not already available from proc_get_status and will return that.