### PR TITLE
fix readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,18 +18,17 @@ composer require utopia-php/cli
 script.php
 ```php
 <?php
-
 require_once './vendor/autoload.php';
 
 use Utopia\CLI\CLI;
 use Utopia\CLI\Console;
-use Utopia\Validator\Email;
+use Utopia\Validator\Wildcard;
 
 $cli = new CLI();
 
 $cli
     ->task('command-name')
-    ->param('email', null, new Email())
+    ->param('email', null, new Wildcard())
     ->action(function ($email) {
         Console::success($email);
     });
@@ -70,8 +69,6 @@ Console::error('Red log message'); // stderr
 
 Function returns exit code (0 - OK, >0 - error) and writes stdout, stderr to reference variables. The timeout variable allows you to limit the number of seconds the command can run.
 
-
-
 ```php
 $stdout = '';
 $stderr = '';
@@ -109,7 +106,7 @@ include './vendor/autoload.php';
 
 Console::loop(function() {
     echo "Hello World\n";
-}, 200000 /* 200ms */);
+}, 1 /* 1 second */);
 ```
 
 ## System Requirements

--- a/src/CLI/Console.php
+++ b/src/CLI/Console.php
@@ -189,16 +189,15 @@ class Console
 
     /**
      * @param callable $callback
-     * @param int $sleep // seconds
+     * @param float $sleep // in seconds!
      * @param callable $onError
-     * @throws \Exception
      */
-    static public function loop(callable $callback, int $sleep = 1 /* 1 second */, callable $onError = null): void
+    static public function loop(callable $callback, $sleep = 1 /* seconds */, callable $onError = null): void
     {
         gc_enable();
 
         $time = 0;
-        
+
         while (!connection_aborted() || PHP_SAPI == "cli") {
             try {
                 $callback();
@@ -210,12 +209,12 @@ class Console
                 }
             }
 
-            sleep($sleep);
+            usleep($sleep * 1000000);
 
             $time = $time + $sleep;
 
             if (PHP_SAPI == "cli") {
-                if($time >= (5 * 60)) { // Every 5 minutes
+                if($time >= $time * 60 * 5) { // Every 5 minutes
                     $time = 0;
                     gc_collect_cycles(); //Forces collection of any existing garbage cycles
                 }

--- a/src/CLI/Console.php
+++ b/src/CLI/Console.php
@@ -189,10 +189,11 @@ class Console
 
     /**
      * @param callable $callback
-     * @param int $sleep in seconds
+     * @param int $sleep // seconds
      * @param callable $onError
+     * @throws \Exception
      */
-    static public function loop(callable $callback, $sleep = 1 /* 1 second */, callable $onError = null): void
+    static public function loop(callable $callback, int $sleep = 1 /* 1 second */, callable $onError = null): void
     {
         gc_enable();
 
@@ -214,7 +215,7 @@ class Console
             $time = $time + $sleep;
 
             if (PHP_SAPI == "cli") {
-                if($time >= (1000000 * 300)) { // Every 5 minutes
+                if($time >= (5 * 60)) { // Every 5 minutes
                     $time = 0;
                     gc_collect_cycles(); //Forces collection of any existing garbage cycles
                 }

--- a/src/CLI/Console.php
+++ b/src/CLI/Console.php
@@ -209,7 +209,16 @@ class Console
                 }
             }
 
-            usleep($sleep * 1000000);
+            $intSeconds = intval($sleep);
+            $microSeconds = ($sleep - $intSeconds) * 1000000;
+
+            if($intSeconds > 0) {
+                sleep($intSeconds);
+            }
+
+            if($microSeconds > 0) {
+                usleep($microSeconds);
+            }
 
             $time = $time + $sleep;
 

--- a/src/CLI/Console.php
+++ b/src/CLI/Console.php
@@ -214,7 +214,7 @@ class Console
             $time = $time + $sleep;
 
             if (PHP_SAPI == "cli") {
-                if($time >= $time * 60 * 5) { // Every 5 minutes
+                if($time >= 60 * 5) { // Every 5 minutes
                     $time = 0;
                     gc_collect_cycles(); //Forces collection of any existing garbage cycles
                 }

--- a/src/CLI/Task.php
+++ b/src/CLI/Task.php
@@ -1,6 +1,7 @@
 <?php
-
 namespace Utopia\CLI;
+
+use Utopia\Validator;
 
 class Task
 {
@@ -80,13 +81,13 @@ class Task
      *
      * @param string $key
      * @param mixed $default
-     * @param string $validator
+     * @param Validator $validator
      * @param string $description
      * @param bool $optional
      *
      * @return $this
      */
-    public function param(string $key, $default, $validator, string $description = '', bool $optional = false): self
+    public function param(string $key, $default, Validator $validator, string $description = '', bool $optional = false): self
     {
         $this->params[$key] = array(
             'default'       => $default,


### PR DESCRIPTION
Fix Readme example. 
Utopia\Validator\Email does not exist, changed to wildcard validator.
Validator is an Object not a String.
Console::loop variable $sleep is in seconds not microseconds + added support for parts of seconds.