### PR TITLE
Use utopia-php/servers instead

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     },
     "require": {
         "php": ">=7.4",
-        "utopia-php/framework": "1.0.*",
-        "utopia-php/di": "0.1.*"
+        "utopia-php/di": "0.1.*",
+        "utopia-php/servers": "dev-main"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=7.4",
         "utopia-php/di": "0.1.*",
-        "utopia-php/servers": "dev-main"
+        "utopia-php/servers": "0.1.*"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d1a7cb9ca663d0c8a80218a3ff5c2d0c",
+    "content-hash": "f0c507914a1056c40db2132d7b99f816",
     "packages": [
         {
             "name": "utopia-php/di",
@@ -55,67 +55,17 @@
             "time": "2024-08-08T14:35:19+00:00"
         },
         {
-            "name": "utopia-php/framework",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/utopia-php/http.git",
-                "reference": "cc880ec41f7f163d4f9956fec26cc6be51b412cf"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/http/zipball/cc880ec41f7f163d4f9956fec26cc6be51b412cf",
-                "reference": "cc880ec41f7f163d4f9956fec26cc6be51b412cf",
-                "shasum": ""
-            },
-            "require": {
-                "ext-swoole": "*",
-                "php": ">=8.0",
-                "utopia-php/servers": "0.1.*"
-            },
-            "require-dev": {
-                "ext-xdebug": "*",
-                "laravel/pint": "^1.2",
-                "phpbench/phpbench": "^1.2",
-                "phpstan/phpstan": "^1.10",
-                "phpunit/phpunit": "^9.5.25",
-                "swoole/ide-helper": "4.8.3"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Utopia\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "A simple, light and advanced PHP HTTP framework",
-            "keywords": [
-                "framework",
-                "http",
-                "php",
-                "upf"
-            ],
-            "support": {
-                "issues": "https://github.com/utopia-php/http/issues",
-                "source": "https://github.com/utopia-php/http/tree/1.0.0"
-            },
-            "time": "2024-09-05T15:38:08+00:00"
-        },
-        {
             "name": "utopia-php/servers",
-            "version": "0.1.0",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/servers.git",
-                "reference": "7d9e4f364fb1ab1889fb89ca96eb9946467cb09c"
+                "reference": "fd5c8d32778f265256c1936372a071b944f5ba8a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/servers/zipball/7d9e4f364fb1ab1889fb89ca96eb9946467cb09c",
-                "reference": "7d9e4f364fb1ab1889fb89ca96eb9946467cb09c",
+                "url": "https://api.github.com/repos/utopia-php/servers/zipball/fd5c8d32778f265256c1936372a071b944f5ba8a",
+                "reference": "fd5c8d32778f265256c1936372a071b944f5ba8a",
                 "shasum": ""
             },
             "require": {
@@ -127,6 +77,7 @@
                 "phpstan/phpstan": "^1.8",
                 "phpunit/phpunit": "^9.5.5"
             },
+            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -153,9 +104,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/servers/issues",
-                "source": "https://github.com/utopia-php/servers/tree/0.1.0"
+                "source": "https://github.com/utopia-php/servers/tree/0.1.1"
             },
-            "time": "2024-08-08T14:31:39+00:00"
+            "time": "2024-09-06T02:25:56+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f0c507914a1056c40db2132d7b99f816",
+    "content-hash": "9811e6f2f332382c4e8a77eb4f7e6da1",
     "packages": [
         {
             "name": "utopia-php/di",
@@ -56,7 +56,7 @@
         },
         {
             "name": "utopia-php/servers",
-            "version": "dev-main",
+            "version": "0.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/servers.git",
@@ -77,7 +77,6 @@
                 "phpstan/phpstan": "^1.8",
                 "phpunit/phpunit": "^9.5.5"
             },
-            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -116,12 +115,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "0dfb69d79d0964b8a80bfa92c07f50e3e8d73542"
+                "reference": "acc12399c90611e3cb478d0ec72f2c2ebbc429d1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0dfb69d79d0964b8a80bfa92c07f50e3e8d73542",
-                "reference": "0dfb69d79d0964b8a80bfa92c07f50e3e8d73542",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/acc12399c90611e3cb478d0ec72f2c2ebbc429d1",
+                "reference": "acc12399c90611e3cb478d0ec72f2c2ebbc429d1",
                 "shasum": ""
             },
             "require": {
@@ -179,7 +178,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-20T19:34:15+00:00"
+            "time": "2024-09-30T20:32:32+00:00"
         },
         {
             "name": "laravel/pint",
@@ -310,16 +309,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.1.0",
+            "version": "v5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "683130c2ff8c2739f4822ff7ac5c873ec529abd1"
+                "reference": "3abf7425cd284141dc5d8d14a9ee444de3345d1a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/683130c2ff8c2739f4822ff7ac5c873ec529abd1",
-                "reference": "683130c2ff8c2739f4822ff7ac5c873ec529abd1",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/3abf7425cd284141dc5d8d14a9ee444de3345d1a",
+                "reference": "3abf7425cd284141dc5d8d14a9ee444de3345d1a",
                 "shasum": ""
             },
             "require": {
@@ -362,9 +361,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.1.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.3.0"
             },
-            "time": "2024-07-01T20:03:41+00:00"
+            "time": "2024-09-29T13:56:26+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -491,12 +490,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "99756056e2447c92b9e9e24801d17a97b415ead6"
+                "reference": "0b9ce983aac24557446c76f28920cfef2e8c067f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/99756056e2447c92b9e9e24801d17a97b415ead6",
-                "reference": "99756056e2447c92b9e9e24801d17a97b415ead6",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/0b9ce983aac24557446c76f28920cfef2e8c067f",
+                "reference": "0b9ce983aac24557446c76f28920cfef2e8c067f",
                 "shasum": ""
             },
             "require": {
@@ -541,7 +540,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-09-05T15:27:23+00:00"
+            "time": "2024-09-30T14:53:31+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -868,12 +867,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "e6a204cd0360ecdb88c200384133df8573abcdb5"
+                "reference": "afe194425e5fbbaa2314f6f845f79fbeb8fa8cb7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e6a204cd0360ecdb88c200384133df8573abcdb5",
-                "reference": "e6a204cd0360ecdb88c200384133df8573abcdb5",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/afe194425e5fbbaa2314f6f845f79fbeb8fa8cb7",
+                "reference": "afe194425e5fbbaa2314f6f845f79fbeb8fa8cb7",
                 "shasum": ""
             },
             "require": {
@@ -963,7 +962,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-04T06:06:52+00:00"
+            "time": "2024-09-29T06:20:47+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -1935,12 +1934,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "f9052410eb9898a3f1780278bb080dfb930b7fe9"
+                "reference": "9168f539e25f4fe09153f32621bc385f25311919"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/f9052410eb9898a3f1780278bb080dfb930b7fe9",
-                "reference": "f9052410eb9898a3f1780278bb080dfb930b7fe9",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/9168f539e25f4fe09153f32621bc385f25311919",
+                "reference": "9168f539e25f4fe09153f32621bc385f25311919",
                 "shasum": ""
             },
             "require": {
@@ -2008,7 +2007,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-09-02T13:22:27+00:00"
+            "time": "2024-09-30T14:35:07+00:00"
         },
         {
             "name": "swoole/ide-helper",

--- a/src/CLI/CLI.php
+++ b/src/CLI/CLI.php
@@ -6,8 +6,8 @@ use Exception;
 use Utopia\CLI\Adapters\Generic;
 use Utopia\DI\Container;
 use Utopia\DI\Dependency;
-use Utopia\Http\Hook;
-use Utopia\Http\Validator;
+use Utopia\Servers\Hook;
+use Utopia\Servers\Validator;
 
 class CLI
 {

--- a/src/CLI/Task.php
+++ b/src/CLI/Task.php
@@ -2,7 +2,7 @@
 
 namespace Utopia\CLI;
 
-use Utopia\Http\Hook;
+use Utopia\Servers\Hook;
 
 class Task extends Hook
 {


### PR DESCRIPTION
- Use low level utopia-php/servers as a replacement for `utopia-php/framework` which is now refactored to `utopia-php/http` and is only for HTTP services