### PR TITLE
feat: allow cli container injection

### DIFF
--- a/src/CLI/CLI.php
+++ b/src/CLI/CLI.php
@@ -33,8 +33,6 @@ class CLI
      */
     protected Container $container;
 
-    protected ?Container $parentContainer = null;
-
     /**
      * Args
      *
@@ -100,8 +98,7 @@ class CLI
         @\cli_set_process_title($this->command);
 
         $this->adapter = $adapter ?? new Generic();
-        $this->parentContainer = $container;
-        $this->container = new Container($container);
+        $this->container = $container ?? new Container();
     }
 
     /**
@@ -412,15 +409,14 @@ class CLI
 
     public function setContainer(Container $container): self
     {
-        $this->parentContainer = $container;
-        $this->container = new Container($container);
+        $this->container = $container;
 
         return $this;
     }
 
     public function reset(): void
     {
-        $this->container = new Container($this->parentContainer);
+        $this->container = new Container();
     }
 
     private function camelCaseIt($key): string

--- a/src/CLI/CLI.php
+++ b/src/CLI/CLI.php
@@ -83,10 +83,11 @@ class CLI
      *
      * @param  Adapter|null  $adapter
      * @param  array  $args
+     * @param  Container|null  $container
      *
      * @throws Exception
      */
-    public function __construct(?Adapter $adapter = null, array $args = [])
+    public function __construct(?Adapter $adapter = null, array $args = [], ?Container $container = null)
     {
         if (\php_sapi_name() !== 'cli') {
             throw new Exception('CLI tasks can only work from the command line');
@@ -97,7 +98,7 @@ class CLI
         @\cli_set_process_title($this->command);
 
         $this->adapter = $adapter ?? new Generic();
-        $this->container = new Container();
+        $this->container = $container ?? new Container();
     }
 
     /**
@@ -211,6 +212,11 @@ class CLI
     public function setResource(string $name, callable $callback, array $dependencies = []): void
     {
         $this->container->set($name, $callback, $dependencies);
+    }
+
+    public function getContainer(): Container
+    {
+        return $this->container;
     }
 
     /**
@@ -401,7 +407,7 @@ class CLI
         }
     }
 
-    public function setContainer($container): self
+    public function setContainer(Container $container): self
     {
         $this->container = $container;
 

--- a/src/CLI/CLI.php
+++ b/src/CLI/CLI.php
@@ -33,6 +33,8 @@ class CLI
      */
     protected Container $container;
 
+    protected ?Container $parentContainer = null;
+
     /**
      * Args
      *
@@ -98,7 +100,8 @@ class CLI
         @\cli_set_process_title($this->command);
 
         $this->adapter = $adapter ?? new Generic();
-        $this->container = $container ?? new Container();
+        $this->parentContainer = $container;
+        $this->container = new Container($container);
     }
 
     /**
@@ -409,14 +412,15 @@ class CLI
 
     public function setContainer(Container $container): self
     {
-        $this->container = $container;
+        $this->parentContainer = $container;
+        $this->container = new Container($container);
 
         return $this;
     }
 
     public function reset(): void
     {
-        $this->container = new Container();
+        $this->container = new Container($this->parentContainer);
     }
 
     private function camelCaseIt($key): string

--- a/tests/CLI/CLITest.php
+++ b/tests/CLI/CLITest.php
@@ -211,8 +211,7 @@ class CLITest extends TestCase
 
         $cli = new CLI(new Generic(), ['test.php', 'build'], $container);
 
-        $this->assertNotSame($container, $cli->getContainer());
-        $this->assertEquals('test-value', $cli->getResource('test'));
+        $this->assertSame($container, $cli->getContainer());
 
         $cli->task('build')
             ->inject('test')
@@ -225,25 +224,6 @@ class CLITest extends TestCase
         $result = ob_get_clean();
 
         $this->assertEquals('test-value', $result);
-    }
-
-    public function testResetPreservesInjectedContainer()
-    {
-        $container = new Container();
-        $container->set('base', fn () => 'base-value');
-
-        $cli = new CLI(new Generic(), ['test.php', 'build'], $container);
-        $cli->setResource('runtime', fn () => 'runtime-value');
-
-        $this->assertEquals('base-value', $cli->getResource('base'));
-        $this->assertEquals('runtime-value', $cli->getResource('runtime'));
-
-        $cli->reset();
-
-        $this->assertEquals('base-value', $cli->getResource('base'));
-
-        $this->expectException(\Exception::class);
-        $cli->getResource('runtime');
     }
 
     public function testMatch()

--- a/tests/CLI/CLITest.php
+++ b/tests/CLI/CLITest.php
@@ -5,6 +5,7 @@ namespace Utopia\Tests;
 use PHPUnit\Framework\TestCase;
 use Utopia\CLI\Adapters\Generic;
 use Utopia\CLI\CLI;
+use Utopia\DI\Container;
 use Utopia\Validator\ArrayList;
 use Utopia\Validator\Text;
 
@@ -199,6 +200,30 @@ class CLITest extends TestCase
         $result = ob_get_clean();
 
         $this->assertEquals('test-value-me@example.com', $result);
+    }
+
+    public function testProvidedContainer()
+    {
+        ob_start();
+
+        $container = new Container();
+        $container->set('test', fn () => 'test-value');
+
+        $cli = new CLI(new Generic(), ['test.php', 'build'], $container);
+
+        $this->assertSame($container, $cli->getContainer());
+
+        $cli->task('build')
+            ->inject('test')
+            ->action(function ($test) {
+                echo $test;
+            });
+
+        $cli->run();
+
+        $result = ob_get_clean();
+
+        $this->assertEquals('test-value', $result);
     }
 
     public function testMatch()

--- a/tests/CLI/CLITest.php
+++ b/tests/CLI/CLITest.php
@@ -211,7 +211,8 @@ class CLITest extends TestCase
 
         $cli = new CLI(new Generic(), ['test.php', 'build'], $container);
 
-        $this->assertSame($container, $cli->getContainer());
+        $this->assertNotSame($container, $cli->getContainer());
+        $this->assertEquals('test-value', $cli->getResource('test'));
 
         $cli->task('build')
             ->inject('test')
@@ -224,6 +225,25 @@ class CLITest extends TestCase
         $result = ob_get_clean();
 
         $this->assertEquals('test-value', $result);
+    }
+
+    public function testResetPreservesInjectedContainer()
+    {
+        $container = new Container();
+        $container->set('base', fn () => 'base-value');
+
+        $cli = new CLI(new Generic(), ['test.php', 'build'], $container);
+        $cli->setResource('runtime', fn () => 'runtime-value');
+
+        $this->assertEquals('base-value', $cli->getResource('base'));
+        $this->assertEquals('runtime-value', $cli->getResource('runtime'));
+
+        $cli->reset();
+
+        $this->assertEquals('base-value', $cli->getResource('base'));
+
+        $this->expectException(\Exception::class);
+        $cli->getResource('runtime');
     }
 
     public function testMatch()


### PR DESCRIPTION
## Summary
- allow injecting a container when constructing `CLI`
- expose the current container with `getContainer()`
- add coverage for using a provided container for task injections

## Testing
- composer test
- composer lint
- composer check
