### PR TITLE
fix: coerce string CLI inputs for Boolean params

### DIFF
--- a/src/CLI/CLI.php
+++ b/src/CLI/CLI.php
@@ -424,7 +424,10 @@ class CLI
      * to happen here at the dispatch boundary.
      *
      * Only string inputs are coerced; bool defaults are passed through
-     * untouched.
+     * untouched. Strings that `filter_var` doesn't recognise (including the
+     * empty string, which bypasses `validate()` for optional params) are
+     * passed through unchanged so callers that use `''` as a sentinel for
+     * "not set" keep working.
      *
      * @param  Validator|callable  $validator
      * @param  mixed  $value
@@ -432,7 +435,7 @@ class CLI
      */
     protected function coerce(Validator|callable $validator, mixed $value): mixed
     {
-        if (! is_string($value)) {
+        if (! is_string($value) || $value === '') {
             return $value;
         }
 
@@ -444,11 +447,13 @@ class CLI
             $validator = $validator->getValidator();
         }
 
-        if ($validator instanceof Boolean) {
-            return \filter_var($value, FILTER_VALIDATE_BOOLEAN);
+        if (! ($validator instanceof Boolean)) {
+            return $value;
         }
 
-        return $value;
+        $coerced = \filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+
+        return $coerced === null ? $value : $coerced;
     }
 
     public function setContainer(Container $container): self

--- a/src/CLI/CLI.php
+++ b/src/CLI/CLI.php
@@ -7,6 +7,8 @@ use Utopia\CLI\Adapters\Generic;
 use Utopia\DI\Container;
 use Utopia\Servers\Hook;
 use Utopia\Validator;
+use Utopia\Validator\Boolean;
+use Utopia\Validator\Nullable;
 
 class CLI
 {
@@ -302,7 +304,7 @@ class CLI
 
             $this->validate($key, $param, $value);
 
-            $params[$this->camelCaseIt($key)] = $value;
+            $params[$this->camelCaseIt($key)] = $this->coerce($param['validator'], $value);
         }
 
         foreach ($hook->getDependencies() as $dependency) {
@@ -408,6 +410,45 @@ class CLI
                 throw new Exception('Param "'.$key.'" is not optional.', 400);
             }
         }
+    }
+
+    /**
+     * Coerce string CLI inputs to native PHP types based on the param's validator.
+     *
+     * CLI args arrive as strings via getopt. When the validator is `Boolean`
+     * (loose mode), strings like "true"/"false"/"1"/"0" pass validation but
+     * remain strings. If the action callback declares a `bool` parameter, PHP's
+     * implicit string-to-bool cast turns any non-empty string except "0" into
+     * `true` -- so `--commit=false` silently becomes `true`. Validators in
+     * utopia-php are pure (validate only, never mutate), so the coercion has
+     * to happen here at the dispatch boundary.
+     *
+     * Only string inputs are coerced; bool defaults are passed through
+     * untouched.
+     *
+     * @param  Validator|callable  $validator
+     * @param  mixed  $value
+     * @return mixed
+     */
+    protected function coerce(Validator|callable $validator, mixed $value): mixed
+    {
+        if (! is_string($value)) {
+            return $value;
+        }
+
+        if (\is_callable($validator)) {
+            $validator = $validator();
+        }
+
+        while ($validator instanceof Nullable) {
+            $validator = $validator->getValidator();
+        }
+
+        if ($validator instanceof Boolean) {
+            return \filter_var($value, FILTER_VALIDATE_BOOLEAN);
+        }
+
+        return $value;
     }
 
     public function setContainer(Container $container): self

--- a/tests/CLI/CLITest.php
+++ b/tests/CLI/CLITest.php
@@ -364,6 +364,30 @@ class CLITest extends TestCase
         $this->assertFalse($captured);
     }
 
+    /**
+     * Empty-string params bypass `validate()` when optional, so they reach
+     * `coerce()` un-validated. We must NOT silently turn them into `false`
+     * (callers like Cloud's `Patch.php` use `''` as a "not set" sentinel and
+     * later resolve it to `null`/three-state).
+     */
+    public function testBooleanParamPreservesEmptyStringSentinel(): void
+    {
+        $captured = 'untouched';
+
+        $cli = new CLI(new Generic(), ['test.php', 'build']);
+
+        $cli
+            ->task('build')
+            ->param('commit', '', new Boolean(true), 'Commit changes', true)
+            ->action(function ($commit) use (&$captured) {
+                $captured = $commit;
+            });
+
+        $cli->run();
+
+        $this->assertSame('', $captured);
+    }
+
     public function testNonBooleanValidatorPassesValueThroughUnchanged(): void
     {
         $captured = null;

--- a/tests/CLI/CLITest.php
+++ b/tests/CLI/CLITest.php
@@ -7,6 +7,8 @@ use Utopia\CLI\Adapters\Generic;
 use Utopia\CLI\CLI;
 use Utopia\DI\Container;
 use Utopia\Validator\ArrayList;
+use Utopia\Validator\Boolean;
+use Utopia\Validator\Nullable;
 use Utopia\Validator\Text;
 
 class CLITest extends TestCase
@@ -287,6 +289,97 @@ class CLITest extends TestCase
             });
 
         $this->assertEquals(null, $cli->match());
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: bool}>
+     */
+    public static function looseBooleanValuesProvider(): iterable
+    {
+        yield '"false" string' => ['false', false];
+        yield '"true" string' => ['true', true];
+        yield '"0" string' => ['0', false];
+        yield '"1" string' => ['1', true];
+    }
+
+    /**
+     * Regression: --flag=false used to arrive as the literal string "false",
+     * which PHP's implicit string-to-bool cast turned into `true` at the
+     * `bool $flag` parameter boundary. The CLI dispatcher now coerces string
+     * inputs whose validator is `Boolean` to a real PHP bool.
+     *
+     * @dataProvider looseBooleanValuesProvider
+     */
+    public function testBooleanParamCoercesStringInput(string $input, bool $expected): void
+    {
+        $captured = null;
+
+        $cli = new CLI(new Generic(), ['test.php', 'build', '--commit='.$input]);
+
+        $cli
+            ->task('build')
+            ->param('commit', false, new Boolean(true), 'Commit changes', true)
+            ->action(function (bool $commit) use (&$captured) {
+                $captured = $commit;
+            });
+
+        $cli->run();
+
+        $this->assertSame($expected, $captured);
+    }
+
+    public function testBooleanParamUsesDefaultWhenOmitted(): void
+    {
+        $captured = null;
+
+        $cli = new CLI(new Generic(), ['test.php', 'build']);
+
+        $cli
+            ->task('build')
+            ->param('commit', false, new Boolean(true), 'Commit changes', true)
+            ->action(function (bool $commit) use (&$captured) {
+                $captured = $commit;
+            });
+
+        $cli->run();
+
+        $this->assertFalse($captured);
+    }
+
+    public function testBooleanParamCoercionUnwrapsNullable(): void
+    {
+        $captured = 'untouched';
+
+        $cli = new CLI(new Generic(), ['test.php', 'build', '--commit=false']);
+
+        $cli
+            ->task('build')
+            ->param('commit', null, new Nullable(new Boolean(true)), 'Commit changes', true)
+            ->action(function (bool $commit) use (&$captured) {
+                $captured = $commit;
+            });
+
+        $cli->run();
+
+        $this->assertFalse($captured);
+    }
+
+    public function testNonBooleanValidatorPassesValueThroughUnchanged(): void
+    {
+        $captured = null;
+
+        $cli = new CLI(new Generic(), ['test.php', 'build', '--name=false']);
+
+        $cli
+            ->task('build')
+            ->param('name', '', new Text(64), 'A name')
+            ->action(function (string $name) use (&$captured) {
+                $captured = $name;
+            });
+
+        $cli->run();
+
+        $this->assertSame('false', $captured);
     }
 
     public function testEscaping()


### PR DESCRIPTION
## Summary

CLI args arrive as strings via getopt. When a param's validator is `Boolean(true)` (loose mode), strings like `"true"`/`"false"`/`"1"`/`"0"` pass validation but remain strings. If the action callback declares a `bool` parameter, PHP's implicit string-to-bool cast turns any non-empty string except `"0"` into `true` — so `--commit=false` silently becomes `true`, and the action runs as if `--commit=true` had been passed.

This bit a real production task: a CLI script ran with `--commit=false` to dry-run, but the write committed anyway because `(bool) "false" === true` in PHP.

## What changed

`CLI::getParams()` now passes each validated value through a small `coerce()` helper before storing it in the params array. If the param's validator (unwrapping `Nullable`) is `Boolean` and the incoming value is still a string, it's normalised via `filter_var(..., FILTER_VALIDATE_BOOLEAN)`. Bool defaults and non-string inputs pass through untouched.

Validators in utopia-php are pure (validate only, never mutate), so the coercion has to live at the dispatch boundary on the consumer side. CLI is the right place because every CLI arg starts life as a string.

## Why not at the validator layer

`utopia-php/validators` validators only validate — they never mutate. Keeping that contract intact, the only place to bridge `string` → `bool` for CLI dispatch is here.

## Behaviour

| Validator                    | CLI input    | Before     | After     |
|------------------------------|--------------|------------|-----------|
| `new Boolean(true)`          | `--c=false`  | `true` ⚠️  | `false` ✅ |
| `new Boolean(true)`          | `--c=true`   | `true`     | `true`    |
| `new Boolean(true)`          | `--c=0`      | `false`    | `false`   |
| `new Boolean(true)`          | `--c=1`      | `true`     | `true`    |
| `new Boolean(true)`          | omitted      | default    | default   |
| `new Nullable(new Boolean(true))` | `--c=false`  | `true` ⚠️  | `false` ✅ |
| `new Text(64)`               | `--n=false`  | `"false"`  | `"false"` |

Non-Boolean validators are completely untouched.

## Test plan

- [x] Existing 18 tests still pass
- [x] New tests cover string `"false"`, `"true"`, `"0"`, `"1"` inputs to `Boolean(true)` params (via data provider)
- [x] New test covers `Nullable(Boolean(true))` unwrapping
- [x] New test covers default-value path when param omitted
- [x] New test covers non-Boolean validator (`Text`) where string `"false"` must remain the string `"false"`
- [x] `composer lint` passes
- [x] `composer check` (phpstan) passes

\`\`\`
\$ composer test
OK (25 tests, 41 assertions)
\`\`\`

## Compatibility

This is additive. Existing callers that already pass real \`bool\` values continue to work. Existing callers that passed \`"false"\` and accidentally got \`true\` were already buggy — this fix gives them the behaviour they presumably intended. Anyone who *needs* the literal string \`"false"\` should be using \`Text\`, not \`Boolean\`.